### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.Interface.nuspec
+++ b/MakoIoT.Device.Platform.Interface.nuspec
@@ -19,8 +19,8 @@
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.52" />
-      <dependency id="nanoFramework.System.Net" version="1.10.72" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.56" />
+      <dependency id="nanoFramework.System.Net" version="1.10.75" />
       <dependency id="nanoFramework.System.Text" version="1.2.54" />
       <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>

--- a/src/MakoIoT.Device.Platform.Interface/MakoIoT.Device.Platform.Interface.nfproj
+++ b/src/MakoIoT.Device.Platform.Interface/MakoIoT.Device.Platform.Interface.nfproj
@@ -36,12 +36,12 @@
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.52.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.52\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.56.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.56\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.72.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.72\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.75\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Platform.Interface/packages.config
+++ b/src/MakoIoT.Device.Platform.Interface/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.52" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.72" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.56" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.75" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.System.IO.Streams from 1.1.52 to 1.1.56</br>Bumps nanoFramework.System.Net from 1.10.72 to 1.10.75</br>
[version update]

### :warning: This is an automated update. :warning:
