### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.Interface.nuspec
+++ b/MakoIoT.Device.Platform.Interface.nuspec
@@ -17,11 +17,11 @@
     <description>MAKO-IoT Platform interface library</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.29" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.86" />
-      <dependency id="nanoFramework.System.Net" version="1.11.27" />
-      <dependency id="nanoFramework.System.Text" version="1.3.16" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.88" />
+      <dependency id="nanoFramework.System.Net" version="1.11.30" />
+      <dependency id="nanoFramework.System.Text" version="1.3.29" />
       <dependency id="nanoFramework.System.Threading" version="1.1.46" />
     </dependencies>
   </metadata>

--- a/src/MakoIoT.Device.Platform.Interface/MakoIoT.Device.Platform.Interface.nfproj
+++ b/src/MakoIoT.Device.Platform.Interface/MakoIoT.Device.Platform.Interface.nfproj
@@ -25,20 +25,20 @@
     <Compile Include="Constants.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.29\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.16.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.86.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.86\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.88.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.88\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.27\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.30\lib\System.Net.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.46.1709, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.46\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Platform.Interface/packages.config
+++ b/src/MakoIoT.Device.Platform.Interface/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.29" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.86" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.27" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.88" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.30" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.46" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.16.11 to 1.17.1</br>Bumps nanoFramework.System.IO.Streams from 1.1.86 to 1.1.88</br>Bumps nanoFramework.System.Net from 1.11.27 to 1.11.30</br>Bumps nanoFramework.System.Text from 1.3.16 to 1.3.29</br>
[version update]

### :warning: This is an automated update. :warning:
